### PR TITLE
Fix Memory leak in array_list.c:array_list_create

### DIFF
--- a/src/engine/array_list/array_list.c
+++ b/src/engine/array_list/array_list.c
@@ -14,8 +14,10 @@ Array_List *array_list_create(usize item_size, usize initial_capacity) {
     list->len = 0;
     list->items = malloc(item_size * initial_capacity);
 
-    if (!list->items)
+    if (!list->items) {
+	    free(list);
 	    ERROR_RETURN(NULL, "Could not allocate memory for Array_List\n");
+    }
 
     return list;
 }


### PR DESCRIPTION
# Fix Memory leak in array_list.c:array_list_create

Free the memory that was allocated for the list if malloc fails to allocate the underlying array